### PR TITLE
Fix typo ajoint -> adjoint

### DIFF
--- a/adjoint.js
+++ b/adjoint.js
@@ -8,7 +8,7 @@ module.exports = adjoint
  * @param {mat2} a the source matrix
  * @returns {mat2} out
  */
-function ajoint(out, a) {
+function adjoint(out, a) {
   // Caching this value is nessecary if out == a
   var a0 =  a[0]
   out[0] =  a[3]


### PR DESCRIPTION
when requiring top level module like 

``` js
> var m = require('gl-mat2')
ReferenceError: adjoint is not defined
```

ReferenceError is thrown due to a typo in adjoint.js
